### PR TITLE
deserialize AutoIncrementColumns object

### DIFF
--- a/src/jsDataSet.js
+++ b/src/jsDataSet.js
@@ -1746,9 +1746,11 @@
                 if (t.staticFilter) {
                     this.staticFilter(dataQuery.fromObject(t.staticFilter));
                 }
-                if (t.autoIncrementColumns) {
-                    this.autoIncrementColumns = _.clone(t.autoIncrementColumns);
-                }
+                _.forEach(t.autoIncrementColumns, function (aiObj) {
+                    var columnName = aiObj.columnName;
+                    var options  = _.pick(aiObj, ['prefixField', 'idLen', 'middleConst', 'selector', 'selectorMask', 'minimum']);
+                    that.autoIncrementColumns[columnName] = new AutoIncrementColumn(columnName, options);
+                });
                 if (t.columns) {
                     this.columns = _.clone(t.columns);
                 }


### PR DESCRIPTION
Added the deserialization of AutoIncrementColumns. Before the modify it used _.clone of the object, now it creates a collection of AutoIncrement Objects.