### PR TITLE
Moved key settings after columns loop in deserialization

### DIFF
--- a/src/jsDataSet.js
+++ b/src/jsDataSet.js
@@ -1765,7 +1765,7 @@
         deSerialize: function (t, deserializeStructure) {
             var that = this;
             if (deserializeStructure) {
-                this.key(t.key.split(','));
+
                 this.tableForReading(t.tableForReading);
                 this.tableForWriting(t.tableForWriting);
                 this.isCached = t.isCached;
@@ -1800,6 +1800,8 @@
                         that.columns[key] = o;
                     });
                 }
+
+                this.key(t.key.split(','));
             }
 
             that.name=this.name;


### PR DESCRIPTION
Moved key settings after columns loop in deserialization. "isPrimaryKey" was not configured on column object after the deserialization.