### PR TITLE
realTable and viewTable properties on DataTable

### DIFF
--- a/src/jsDataSet.js
+++ b/src/jsDataSet.js
@@ -1595,6 +1595,40 @@
         },
 
         /**
+         * Get/Set a table name, that represents the view table associated to the table
+         * @method viewTable
+         * @param {string} [arg]
+         * @returns {*|string}
+         */
+        viewTable: function (arg) {
+            if (arg === undefined) {
+                if (this.hasOwnProperty('myViewTable')) {
+                    return this.myViewTable;
+                }
+                return false;
+            }
+            this.myViewTable = arg;
+            return this;
+        },
+
+        /**
+         * Get/Set a table name, that represents the real table associated to the table
+         * @method realTable
+         * @param {string} [arg]
+         * @returns {*|string}
+         */
+        realTable: function (arg) {
+            if (arg === undefined) {
+                if (this.hasOwnProperty('myRealTable')) {
+                    return this.myRealTable;
+                }
+                return false;
+            }
+            this.myRealTable = arg;
+            return this;
+        },
+
+        /**
          * Get/Set the name of table  to be used to read data from database in a Jquery fashioned style
          * @method tableForReading
          * @param {string} [tableName]
@@ -1717,6 +1751,8 @@
                 }
                 t.skipSecurity = this.skipSecurity();
                 t.skipInsertCopy = this.skipInsertCopy();
+                t.realTable = this.realTable();
+                t.viewTable = this.viewTable();
                 t.defaults = this.defaults();
                 t.autoIncrementColumns = this.autoIncrementColumns;
                 t.columns = {};
@@ -1773,6 +1809,8 @@
 
                 this.skipSecurity(t.skipSecurity);
                 this.skipInsertCopy(t.skipInsertCopy);
+                this.realTable(t.realTable);
+                this.viewTable(t.viewTable);
                 this.defaults(t.defaults);
                 this.orderBy(t.orderBy);
                 if (t.staticFilter) {
@@ -1880,6 +1918,8 @@
             cloned.staticFilter(this.staticFilter());
             cloned.skipSecurity(this.skipSecurity());
             cloned.skipInsertCopy(this.skipInsertCopy());
+            cloned.realTable(this.realTable());
+            cloned.viewTable(this.viewTable());
             cloned.defaults(this.defaults());
             cloned.autoIncrementColumns = _.clone(this.autoIncrementColumns);
             cloned.columns = _.clone(this.columns);


### PR DESCRIPTION
"realTable" and "viewTable" are useful properties, to configure some info for server business logic. For example you can specify for a table of the dataset which is the table where read the values for the column that have specified the "viewSource"